### PR TITLE
Added copy URL on click feature

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { storage } from "../firebase";
 
+import { FileUrl } from "./FileUrl";
+
 const dynamicLinkEndpoint = "https://firebasedynamiclinks.googleapis.com/v1/shortLinks?key=";
 
 type Props = {
@@ -54,7 +56,7 @@ export const FileUpload = (props: Props) => {
 			<p>File Name: {props.file.name}</p>
 			<p>File Size: {props.file.size}</p>
 			<p>{loadFile}%</p>
-			<p>{fileUrl}</p>
+			{ fileUrl && <FileUrl url={fileUrl} />}
 			{ error && (<p>ERROR: {error}</p>)}
 		</div>
 	)

--- a/src/components/FileUrl.tsx
+++ b/src/components/FileUrl.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from "react";
+
+type Props = {
+	url: string,
+}
+
+export const FileUrl = (props: Props) => {
+	const handleClick: React.MouseEventHandler<HTMLInputElement> = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+		navigator.clipboard.writeText(props.url);
+		e.currentTarget.select();
+	}
+
+	return (
+		<input className="w-60 p-1 text-center rounded-md"
+		onClick={handleClick}
+		readOnly={true}
+		value={props.url} />
+	)
+}


### PR DESCRIPTION
Allows you to copy the URL to clipboard when clicking the readonly input element.

This commit also hides the FileUrl component unless there is already a URL created.