### PR TITLE
Add 5 file limit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,14 +5,16 @@ import { FileUpload } from "./components/FileUpload";
 
 export const App = () => {
 	const [uploads, setUploads] = useState<File[] | null>(null);
+	const [error, setError] = useState("");
 
 	return (
 		<div>
+			{ error && (<p>ERROR: {error}</p>)}
 			{ uploads ?
 				uploads.map(file => (<FileUpload key={uploads.indexOf(file)} file={file} />))
 				: <>
-					<DragAndDrop setUploads={setUploads} />
-					<UploadButton setUploads={setUploads} />
+					<DragAndDrop setUploads={setUploads} setError={setError} />
+					<UploadButton setUploads={setUploads} setError={setError} />
 				</> }
 		</div>
 	)

--- a/src/components/DragAndDrop.tsx
+++ b/src/components/DragAndDrop.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 type Props = {
 	setUploads: React.Dispatch<React.SetStateAction<File[] | null>>,
-	setError: React.Dispatch<string>,
+	setError: React.Dispatch<React.SetStateAction<string>>,
 }
 
 export const DragAndDrop = (props: Props) => {

--- a/src/components/DragAndDrop.tsx
+++ b/src/components/DragAndDrop.tsx
@@ -12,7 +12,7 @@ export const DragAndDrop = (props: Props) => {
 
 		const { files } = e.dataTransfer;
 
-		if (!files) return
+		if (!files) return;
 
 		if (files.length > 5) {
 			props.setError("Only up to 5 files can be uploaded at once.");

--- a/src/components/DragAndDrop.tsx
+++ b/src/components/DragAndDrop.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 type Props = {
 	setUploads: React.Dispatch<React.SetStateAction<File[] | null>>,
+	setError: React.Dispatch<string>,
 }
 
 export const DragAndDrop = (props: Props) => {
@@ -10,7 +11,15 @@ export const DragAndDrop = (props: Props) => {
 		e.stopPropagation();
 
 		const { files } = e.dataTransfer;
-		if (files && files.length) props.setUploads([...files]);
+
+		if (!files) return
+
+		if (files.length > 5) {
+			props.setError("Only up to 5 files can be uploaded at once.");
+		} else if (files.length) {
+			props.setUploads([...files]);
+		}
+
 	}
 
 	const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {

--- a/src/components/UploadButton.tsx
+++ b/src/components/UploadButton.tsx
@@ -2,12 +2,20 @@ import React from "react"
 
 type Props = {
 	setUploads: React.Dispatch<React.SetStateAction<File[] | null>>,
+	setError: React.Dispatch<string>,
 }
 
 export const UploadButton = (props: Props) => {
 	const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const { files } = e.target;
-		if (files && files.length) props.setUploads([...files]);
+
+		if (!files) return
+
+		if (files.length > 5) {
+			props.setError("Only up to 5 files can be uploaded at once.");
+		} else if (files.length) {
+			props.setUploads([...files]);
+		}
 	}
 
 	return (

--- a/src/components/UploadButton.tsx
+++ b/src/components/UploadButton.tsx
@@ -9,7 +9,7 @@ export const UploadButton = (props: Props) => {
 	const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const { files } = e.target;
 
-		if (!files) return
+		if (!files) return;
 
 		if (files.length > 5) {
 			props.setError("Only up to 5 files can be uploaded at once.");

--- a/src/components/UploadButton.tsx
+++ b/src/components/UploadButton.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 type Props = {
 	setUploads: React.Dispatch<React.SetStateAction<File[] | null>>,
-	setError: React.Dispatch<string>,
+	setError: React.Dispatch<React.SetStateAction<string>>,
 }
 
 export const UploadButton = (props: Props) => {


### PR DESCRIPTION
The number of files is checked in the `DragAndDrop` and `UploadButton` components. A new error state setter is passed to them since `FileUpload` does not get executed in case of `files.length > 5` and so its error state can not be used.